### PR TITLE
Define type specs for options accepted by backends and formatter

### DIFF
--- a/src/lager_graylog.erl
+++ b/src/lager_graylog.erl
@@ -1,6 +1,6 @@
 -module(lager_graylog).
 
--export_type([host/0, port_number/0, mask/0]).
+-export_type([host/0, port_number/0, mask/0, backend_option/0]).
 
 -type host() :: inet:hostname().
 -type port_number() :: inet:port_number().
@@ -8,3 +8,8 @@
 %% log level mask - definition taken from lager
 -type mask() :: {mask, integer()}.
 
+-type backend_option() :: {host, host()}
+                        | {port, port_number()}
+                        | {level, lager:log_level()}
+                        | {formatter, module()}
+                        | {formatter_config, term()}.

--- a/src/lager_graylog_gelf_formatter.erl
+++ b/src/lager_graylog_gelf_formatter.erl
@@ -2,6 +2,12 @@
 
 -export([format/2]).
 
+-export_type([option/0]).
+
+-type option() :: {metadata, all | [atom()], {module(), Function :: atom()}}
+                | {include_timestamp, boolean()}
+                | {override_host, string() | binary()}.
+
 -type severity_int() :: 0..7.
 -type formattable_term() :: binary()
                           | string()
@@ -19,7 +25,7 @@
 
 %% API
 
--spec format(lager_msg:lager_msg(), list()) -> iodata().
+-spec format(lager_msg:lager_msg(), [option()]) -> iodata().
 format(Message, Opts) ->
 	Host = get_host(Opts),
     ShortMessage = lager_msg:message(Message),
@@ -35,7 +41,7 @@ format(Message, Opts) ->
 
 %% Helpers
 
--spec get_host(list()) -> val().
+-spec get_host([option()]) -> val().
 get_host(Opts) ->
 	case proplists:lookup(override_host, Opts) of
         {override_host, Host} ->
@@ -45,14 +51,14 @@ get_host(Opts) ->
             Host
     end.
 
--spec timestamp_prop(erlang:timestamp(), list()) -> [kv()].
+-spec timestamp_prop(erlang:timestamp(), [option()]) -> [kv()].
 timestamp_prop(Timestamp, Opts) ->
     case proplists:get_value(include_timestamp, Opts, true) of
        true  -> [{<<"timestamp">>, erlang_ts_to_gelf_ts(Timestamp)}];
        false -> []
     end.
 
--spec extract_metadata(lager_msg:lager_msg(), list()) -> [kv()].
+-spec extract_metadata(lager_msg:lager_msg(), [option()]) -> [kv()].
 extract_metadata(Message, Opts) ->
 	AllMetadata = lager_msg:metadata(Message),
     case proplists:get_value(metadata, Opts, all) of

--- a/src/lager_graylog_tcp_backend.erl
+++ b/src/lager_graylog_tcp_backend.erl
@@ -25,6 +25,7 @@
 
 %% gen_event callbacks
 
+-spec init([lager_graylog:backend_option()]) -> {ok, state()} | {error, {invalid_opts, term()}}.
 init(Opts) ->
     case lager_graylog_utils:parse_common_opts(Opts) of
         {ok, Config} ->

--- a/src/lager_graylog_udp_backend.erl
+++ b/src/lager_graylog_udp_backend.erl
@@ -21,6 +21,8 @@
 
 %% gen_event callbacks
 
+-spec init([lager_graylog:backend_option()]) ->
+    {ok, state()} | {error, {invalid_opts | gen_udp_open_failed, term()}}.
 init(Opts) ->
     case lager_graylog_utils:parse_common_opts(Opts) of
         {ok, Config} ->


### PR DESCRIPTION
Backend options will probably diverge in the future, but we can keep them consistent for now.