### PR TITLE
JSON encoder and metadata formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,33 @@ messages according to GELF version 1.1. The following fields are always included
 * `"short_message"` - the log message
 * `"level"` - the log severity formatted as a number as in [syslog](https://en.wikipedia.org/wiki/Syslog#Severity_level)
 
-In addition, all metadata provided by lager in the log message will be included as additional fields
-(thus prefixed with `_`). Please note that this formatter can only format binaries, strings, atoms,
-integers, floats (always formatted with 6 decimal places), references, ports and pids.
+#### Metadata
+
+All metadata provided by lager in the log message will be included as additional fields
+(thus prefixed with `_` in the GELF payload). There are a couple things worth mentioning here:
+
+* Metadata keys have to be either atoms, binaries or iolists (including simple strings).
+* allowed characters in metadata keys are letters, numbers, underscores, dashes and dots. Note that
+  the formatter won't validate the keys: make sure that they consist of valid characters or
+  otherwise you might experience problems with Graylog.
+* It is recommended to not include `id` metadata key  because Graylog server will ignore it anyway.
+
+Below you can find the table showing how metadata values on the Erlang side map to the JSON values
+in the GELF message sent to Graylog:
+
+| type          | Erlang                                 | GELF                                      |
+|---------------|----------------------------------------|-------------------------------------------|
+| `atom()`      | `atom`                                 | `"atom"`                                  |
+| `integer()`   | `23`                                   | `23`                                      |
+| `float()`     | `1.23`                                 | `1.23`                                    |
+| `binary()`    | `<<"alice has a cat">>`; `<<1, 2, 3>>` | `"<<\"alice has a cat\">>"; "<<1,2,3>>"`  |
+| `list()`      | `"alice has a cat"`; `[1, 2, 3]`       | `"\"alice has a cat\""`; `"[1,2,3]"`      |
+| `bitstring()` | `<<1:3>>`                              | `"<<1:3>>"`                               |
+| `tuple()`     | `{1, 2, 3}`                            | `"{1,2,3}"`                               |
+| `map()`       | `#{alice => "has a cat"}`              | `"#{alice => \"has a cat\"}"`             |
+| `pid()`       | `<0.68.0>`                             | `"<0.68.0>"`                              |
+| `reference()` | `#Ref<0.4168780290.2597847048.103549>` | `"#Ref<0.4168780290.2597847048.103549>"`  |
+
 
 #### Configuration
 

--- a/rebar.config
+++ b/rebar.config
@@ -3,14 +3,8 @@
             {parse_transform, lager_transform}
            ]}.
 
-{minimum_otp_vsn, "19.0"}.
-
 {deps, [
         {lager, "3.2.4"},
-        {backoff, "1.1.3"}
+        {backoff, "1.1.3"},
+        {jiffy, "0.15.1"}
        ]}.
-
-{profiles,
- [{test, [{deps, [
-                  {jsx, "2.9.0"}
-                 ]}]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,12 @@
 {"1.1.0",
 [{<<"backoff">>,{pkg,<<"backoff">>,<<"1.1.3">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.15.1">>},0},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0}]}.
 [
 {pkg_hash,[
  {<<"backoff">>, <<"DE762C05ED6DFAE862D83DC9E58AE936792B01302B3595F5CFFE86F2D8E6C1DD">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"jiffy">>, <<"BE83B09388DA1A6C7E798207C9D6A1C4D71BB95FCC387D37D35861788F49AB97">>},
  {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>}]}
 ].

--- a/test/lager_graylog_gelf_formatter_SUITE.erl
+++ b/test/lager_graylog_gelf_formatter_SUITE.erl
@@ -99,7 +99,7 @@ metadata_fun(_) ->
 
 -spec decode(iodata()) -> map().
 decode(JSON) when is_binary(JSON) ->
-    jsx:decode(JSON, [return_maps]);
+    jiffy:decode(JSON, [return_maps]);
 decode(JSON) ->
     decode(iolist_to_binary(JSON)).
 

--- a/test/lager_graylog_gelf_formatter_SUITE.erl
+++ b/test/lager_graylog_gelf_formatter_SUITE.erl
@@ -24,7 +24,8 @@ all() ->
      list_metadata_formatting,
      tuple_metadata_formatting,
      map_metadata_formatting,
-     bitstring_metadata_formatting
+     bitstring_metadata_formatting,
+     formats_iolist_message_correctly
     ].
 
 %% Test cases
@@ -157,6 +158,15 @@ map_metadata_formatting(_Config) ->
 
 bitstring_metadata_formatting(_Config) ->
     assert_metadata_format([{<<1:3>>, <<"<<1:3>>">>}]).
+
+formats_iolist_message_correctly(_Config) ->
+    IolistMsg = ["alice", ["has" | "a"], <<"cat">>, 20],
+    Log = lager_msg:new(IolistMsg, erlang:timestamp(), debug, [], []),
+
+    Formatted = lager_graylog_gelf_formatter:format(Log, []),
+
+    Gelf = decode(Formatted),
+    ?assertEqual(iolist_to_binary(IolistMsg), maps:get(<<"short_message">>, Gelf)).
 
 metadata_fun(_) ->
     [{meta, "sample"}].

--- a/test/lager_graylog_gelf_formatter_SUITE.erl
+++ b/test/lager_graylog_gelf_formatter_SUITE.erl
@@ -25,6 +25,7 @@ formats_log_with_mandatory_attributes(_Config) ->
     Log = lager_msg:new(Message, Timestamp, debug, [], []),
 
     Formatted = lager_graylog_gelf_formatter:format(Log, []),
+    ct:pal("~s", [Formatted]),
 
     Gelf = decode(Formatted),
     ?assertEqual(<<"1.1">>, maps:get(<<"version">>, Gelf)),

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -107,7 +107,7 @@ close(RecvSocket) ->
 flush(RecvSocket) ->
     Data = iolist_to_binary(recv(RecvSocket)),
     Logs = binary:split(Data, <<0>>, [trim_all, global]),
-    [jsx:decode(Log, [return_maps]) || Log <- Logs].
+    [jiffy:decode(Log, [return_maps]) || Log <- Logs].
 
 -spec recv(gen_tcp:socket()) -> binary().
 recv(RecvSocket) ->

--- a/test/lager_graylog_udp_backend_SUITE.erl
+++ b/test/lager_graylog_udp_backend_SUITE.erl
@@ -85,7 +85,7 @@ open() ->
 -spec flush(gen_udp:socket()) -> [map()].
 flush(Socket) ->
     Packets = recv(Socket),
-    [jsx:decode(Packet, [return_maps]) || Packet <- Packets].
+    [jiffy:decode(Packet, [return_maps]) || Packet <- Packets].
 
 -spec recv(gen_udp:socket()) -> ok.
 recv(Socket) ->


### PR DESCRIPTION
This PR introduces JSON encoder to encode GELF payload (previously we had problems with unescaped characters in string and binaries). I've also tested and documented how metadata values are encoded - I've chosen an approach similar to how lager's console backend displays metadata values. 