### PR TITLE
Add ability to keep state for gelf formatters.

### DIFF
--- a/src/lager_graylog_formatter.erl
+++ b/src/lager_graylog_formatter.erl
@@ -1,4 +1,4 @@
--module(lager_graylog_gelf_formatter_behaviour).
+-module(lager_graylog_formatter).
 
 %% Called once on backend process start.
 %% Returned value will be stored in process state and passed to

--- a/src/lager_graylog_gelf_formatter.erl
+++ b/src/lager_graylog_gelf_formatter.erl
@@ -7,6 +7,8 @@
 
 -export_type([option/0]).
 
+-behaviour(lager_graylog_gelf_formatter_behaviour).
+
 -type option() :: {metadata, all | [atom()], {module(), Function :: atom()}}
                 | {include_timestamp, boolean()}
                 | {override_host, string() | binary()}

--- a/src/lager_graylog_gelf_formatter.erl
+++ b/src/lager_graylog_gelf_formatter.erl
@@ -7,7 +7,7 @@
 
 -export_type([option/0]).
 
--behaviour(lager_graylog_gelf_formatter_behaviour).
+-behaviour(lager_graylog_formatter).
 
 -type option() :: {metadata, all | [atom()], {module(), Function :: atom()}}
                 | {include_timestamp, boolean()}

--- a/src/lager_graylog_gelf_formatter.erl
+++ b/src/lager_graylog_gelf_formatter.erl
@@ -1,6 +1,9 @@
 -module(lager_graylog_gelf_formatter).
 
--export([format/2]).
+-export([
+         init/1,
+         format/3
+        ]).
 
 -export_type([option/0]).
 
@@ -13,8 +16,10 @@
 
 %% API
 
--spec format(lager_msg:lager_msg(), [option()]) -> iodata().
-format(Message, Opts) ->
+init(_Opts) -> undefined.
+
+-spec format(lager_msg:lager_msg(), undefined, [option()]) -> iodata().
+format(Message, _State, Opts) ->
 	Host = get_host(Opts),
     ShortMessage = lager_msg:message(Message),
     Level = lager_graylog_gelf_utils:severity_to_int(lager_msg:severity(Message)),

--- a/src/lager_graylog_gelf_formatter_behaviour.erl
+++ b/src/lager_graylog_gelf_formatter_behaviour.erl
@@ -1,0 +1,9 @@
+-module(lager_graylog_gelf_formatter_behaviour).
+
+%% Called once on backend process start.
+%% Returned value will be stored in process state and passed to
+%% each format call.
+-callback init(Options :: any()) -> FormatterState :: term().
+
+-callback format(lager_msg:lager_msg(), FormatterState :: term(), Options :: any()) ->
+    FormattedMessage :: iodata().


### PR DESCRIPTION
Sometimes, it's make sense to have internal state for formatter.
For example in my formatter I want to collect some properties of
my system once on the start and send them with each messages.
Also, in my formatter I decide to cache host once it will be resolved,
because looks like cash was removed from 
https://github.com/erlang/otp/blob/master/lib/kernel/src/inet.erl#L466
So, in my case I prefer to use potentialy outdated hostname instead of
getting potential performance issues.
There is possible to implement such state cache with another approaches
(like external memoisation libs) but I believe that with simply introducing
internal state we will cover most of the cases.
Unfortunately, this changes will be breaking for formatters interface,
but I guess, that there is not so many custom formatters in the wild for today.
P.S. (Some additional PR in the queue F.E chuncking support in udp backend :))