### PR TITLE
Repeat TCP-backend tests for SSL with ct-groups

### DIFF
--- a/src/lager_graylog_utils.erl
+++ b/src/lager_graylog_utils.erl
@@ -34,7 +34,7 @@ parse_common_opts(Opts) when is_list(Opts) ->
     AddressFamily   = proplists:get_value(address_family, Opts),
     Formatter    = proplists:get_value(formatter, Opts, lager_graylog_gelf_formatter),
     FormatterConfig = proplists:get_value(formatter_config, Opts, []),
-    Transport = proplists:get_value(itransport, Opts, gen_tcp),
+    Transport = proplists:get_value(transport, Opts, gen_tcp),
     ExtraConnectOpts = proplists:get_value(extra_connect_opts, Opts, []),
 
     OptsWithDefaults = [{level, Level},

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -92,6 +92,8 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
 
     Log1 = log(info, "log message 1"),
     Logs1 = flush(?config(transport, Config), RecvSocket1),
+    assert_logged(Logs1, [Log1]),
+
     close(Transport, RecvSocket1),
     % When the connection-closed, the backend tries to create a new connection.
     % With TCP the new connection is pending on the server 'accept'-ing the connection.
@@ -113,7 +115,7 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
     Log3 = log(info, "log message 3"),
 
     RecvSocket2 = accept(Transport, ListenSocket),
-    timer:sleep(100),
+    timer:sleep(500),
 
     Log4 = log(info, "log message 4"),
     Logs2 = flush(Transport, RecvSocket2),

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -8,16 +8,7 @@
 -define(HOST, {127, 0, 0, 1}).
 
 -ifdef(OTP_RELEASE).
--if(?OTP_RELEASE >= 22).
 -define(SSL_HANDSHAKE(TransportAccept), ssl:handshake(TransportAccept)).
--elif(?OTP_RELEASE >= 21).
--define(SSL_HANDSHAKE(TransportAccept),
-        begin
-            TransportSocket = TransportAccept,
-            ok = ssl:ssl_accept(TransportSocket),
-            {ok, TransportSocket}
-        end).
--endif.
 -else.
 -define(SSL_HANDSHAKE(TransportAccept),
         begin
@@ -115,6 +106,7 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
     %
     % To get a consistent behaviour, the server has to be recreated here:
     close(Transport, ?config(socket, Config)),
+    timer:sleep(100),
     {ListenSocket, Port} = listen(Transport, Port),
 
     Log2 = log(info, "log message 2"),

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -113,6 +113,7 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
     Log3 = log(info, "log message 3"),
 
     RecvSocket2 = accept(Transport, ListenSocket),
+    timer:sleep(100),
 
     Log4 = log(info, "log message 4"),
     Logs2 = flush(Transport, RecvSocket2),

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -115,9 +115,10 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
     Log3 = log(info, "log message 3"),
 
     RecvSocket2 = accept(Transport, ListenSocket),
-    timer:sleep(500),
-
+    timer:sleep(100),
     _TryConnectingLog = log(info, "Force Connection Retry"),
+    timer:sleep(100),
+
     Log4 = log(info, "log message 4"),
     Logs2 = flush(Transport, RecvSocket2),
 

--- a/test/lager_graylog_tcp_backend_SUITE.erl
+++ b/test/lager_graylog_tcp_backend_SUITE.erl
@@ -117,6 +117,7 @@ drops_log_messages_if_there_is_no_connection_and_reconnects_later(Config) ->
     RecvSocket2 = accept(Transport, ListenSocket),
     timer:sleep(500),
 
+    _TryConnectingLog = log(info, "Force Connection Retry"),
     Log4 = log(info, "log message 4"),
     Logs2 = flush(Transport, RecvSocket2),
 


### PR DESCRIPTION
* Fix a typo in configuring the transport
* Set a default send-timeout when connecting
* Recreate test-server when testing for skipped logs